### PR TITLE
Add project-specific table to mysql measurements overview 

### DIFF
--- a/iotdb-benchmark/conf/config.properties
+++ b/iotdb-benchmark/conf/config.properties
@@ -21,7 +21,7 @@ DB_URL=http://10.0.0.6:8086
 DB_SWITCH=InfluxDB
 #Database name, only required for InfluxDB and TimescaleDB
 DB_NAME=benchmark
-# Project ID to specify a name for a given benchmarking project
+# Project ID to specify a name for a given benchmarking project. Can be 'None' if not wanted.
 PROJECT_ID=INGESTION_NUM_CLIENTS_INCREASE
 ### benchmark work mode ###
 #目前支持多种运行模式，分别为：

--- a/iotdb-benchmark/conf/config.properties
+++ b/iotdb-benchmark/conf/config.properties
@@ -22,7 +22,7 @@ DB_SWITCH=InfluxDB
 #Database name, only required for InfluxDB and TimescaleDB
 DB_NAME=benchmark
 # Project ID to specify a name for a given benchmarking project. Can be 'None' if not wanted.
-PROJECT_ID=INGESTION_NUM_CLIENTS_INCREASE
+PROJECT_ID=TEST_INGESTION
 PROJECT_TYPE=INGESTION
 ### benchmark work mode ###
 #目前支持多种运行模式，分别为：

--- a/iotdb-benchmark/conf/config.properties
+++ b/iotdb-benchmark/conf/config.properties
@@ -23,6 +23,7 @@ DB_SWITCH=InfluxDB
 DB_NAME=benchmark
 # Project ID to specify a name for a given benchmarking project. Can be 'None' if not wanted.
 PROJECT_ID=INGESTION_NUM_CLIENTS_INCREASE
+PROJECT_TYPE=INGESTION
 ### benchmark work mode ###
 #目前支持多种运行模式，分别为：
 #testWithDefaultPath--常规测试模式，支持多种读和写操作的混合负载

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
@@ -245,7 +245,7 @@ public class Config {
 	// Custom Extensions:
 	/** Specify a Project ID for your measurements to group them */
 	public String PROJECT_ID = "dummyProject";
-	public String PROJECT_MEASUREMENTS = "INGESTION";
+	public String PROJECT_TYPE = "INGESTION";
 
 	public void initInnerFunction() {
 		FunctionXml xml = null;

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
@@ -245,6 +245,7 @@ public class Config {
 	// Custom Extensions:
 	/** Specify a Project ID for your measurements to group them */
 	public String PROJECT_ID = "dummyProject";
+	public String PROJECT_MEASUREMENTS = "INGESTION";
 
 	public void initInnerFunction() {
 		FunctionXml xml = null;

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
@@ -166,6 +166,7 @@ public class ConfigDescriptor {
 
 				// custom extensions:
 				config.PROJECT_ID = properties.getProperty("PROJECT_ID", config.PROJECT_ID + "");
+				config.PROJECT_MEASUREMENTS = properties.getProperty("PROJECT_MEASUREMENTS", config.PROJECT_MEASUREMENTS + "");
 
         config.REAL_INSERT_RATE = Double.parseDouble(properties.getProperty("REAL_INSERT_RATE", config.REAL_INSERT_RATE+""));
 				if(config.REAL_INSERT_RATE <= 0 || config.REAL_INSERT_RATE > 1) {

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
@@ -166,7 +166,7 @@ public class ConfigDescriptor {
 
 				// custom extensions:
 				config.PROJECT_ID = properties.getProperty("PROJECT_ID", config.PROJECT_ID + "");
-				config.PROJECT_MEASUREMENTS = properties.getProperty("PROJECT_MEASUREMENTS", config.PROJECT_MEASUREMENTS + "");
+				config.PROJECT_TYPE = properties.getProperty("PROJECT_TYPE", config.PROJECT_TYPE + "");
 
         config.REAL_INSERT_RATE = Double.parseDouble(properties.getProperty("REAL_INSERT_RATE", config.REAL_INSERT_RATE+""));
 				if(config.REAL_INSERT_RATE <= 0 || config.REAL_INSERT_RATE > 1) {

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -119,10 +119,12 @@ public class MySqlRecorder implements ITestDataPersistence {
         LOGGER.info("Table STATS_OVERVIEW create success!");
       }
       if (isProjectWanted() && !hasTable(projectTableName)) {
+        LOGGER.info("############################# We should create the metric specific table now");
         if (config.PROJECT_TYPE.toLowerCase() == "ingestion") {
-          String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
-          stat.executeUpdate(sql);
-          LOGGER.info("Table {} create success!", projectTableName);
+            LOGGER.info("############################# Okay good");
+            String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
+            stat.executeUpdate(sql);
+            LOGGER.info("Table {} create success!", projectTableName);
         } // else not supported yet. Only ingestion supported right now.
       }
       if (config.BENCHMARK_WORK_MODE.equals(Constants.MODE_TEST_WITH_DEFAULT_PATH) && !hasTable(

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -26,7 +26,7 @@ public class MySqlRecorder implements ITestDataPersistence {
   private static final String SAVE_CONFIG = "insert into CONFIG values(NULL, %s, %s, %s)";
   private static final String SAVE_RESULT_FINAL = "insert into FINAL_RESULT values(NULL, '%s', '%s', '%s', '%s')";
   private static final String SAVE_RESULT_OVERVIEW = "insert into STATS_OVERVIEW values(NULL, '%s', '%s', '%s', '%s')";
-  private static final String INGESTION_CREATE_STATEMENT = "create table %s (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE);";
+  private static final String INGESTION_CREATE_STATEMENT = "create table %s (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP_RATE INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE);";
   private static final String INGESTION_INSERT_STATEMENT = "insert into %s values(NULL, %i, %i, %i, %i, %i, %i, %d, %i, %d)";
 
   private Connection mysqlConnection = null;
@@ -119,10 +119,9 @@ public class MySqlRecorder implements ITestDataPersistence {
         LOGGER.info("Table STATS_OVERVIEW create success!");
       }
       if (isProjectWanted() && !hasTable(projectTableName)) {
-        LOGGER.info("####### We should create the metric specific table now. Project Type = '" + config.PROJECT_TYPE + "'");
         if (config.PROJECT_TYPE.toLowerCase().contains("ingestion")) {
-            LOGGER.info("********************** Okay good");
             String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
+            LOGGER.info("SQL that will be executed: " + sql);
             stat.executeUpdate(sql);
             LOGGER.info("Table {} create success!", projectTableName);
         } // else not supported yet. Only ingestion supported right now.
@@ -231,9 +230,9 @@ public class MySqlRecorder implements ITestDataPersistence {
   }
 
   public String formatIngestionInsertStatement(String value){
-    // format looks like (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE)
+    // format looks like (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP_RATE INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE)
     return String.format(INGESTION_INSERT_STATEMENT, projectTableName, config.CLIENT_NUMBER, config.GROUP_NUMBER, config.DEVICE_NUMBER,
-            config.SENSOR_NUMBER, config.BATCH_SIZE, config.REAL_INSERT_RATE, config.POINT_STEP, Double.parseDouble(value));
+            config.SENSOR_NUMBER, config.BATCH_SIZE, config.LOOP, config.REAL_INSERT_RATE, config.POINT_STEP, Double.parseDouble(value));
   }
 
   // save the measurement results to three different tables: FINAL_RESULT, STATS_OVERVIEW and the project specific table

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -119,7 +119,7 @@ public class MySqlRecorder implements ITestDataPersistence {
         LOGGER.info("Table STATS_OVERVIEW create success!");
       }
       if (isProjectWanted() && !hasTable(projectTableName)) {
-        LOGGER.info("############################# We should create the metric specific table now");
+        LOGGER.info("############################# We should create the metric specific table now. Project Type = " + config.PROJECT_TYPE);
         if (config.PROJECT_TYPE.toLowerCase() == "ingestion") {
             LOGGER.info("############################# Okay good");
             String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -233,7 +233,7 @@ public class MySqlRecorder implements ITestDataPersistence {
     return String.format(INGESTION_INSERT_STATEMENT, projectTableName, config.CLIENT_NUMBER, config.GROUP_NUMBER, config.DEVICE_NUMBER, Double.parseDouble(value));
   }
 
-  // 存储实验结果
+  // save the measurement results to three different tables: FINAL_RESULT, STATS_OVERVIEW and the project specific table
   @Override
   public void saveResult(String operation, String k, String v) {
     Statement stat = null;

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -26,8 +26,8 @@ public class MySqlRecorder implements ITestDataPersistence {
   private static final String SAVE_CONFIG = "insert into CONFIG values(NULL, %s, %s, %s)";
   private static final String SAVE_RESULT_FINAL = "insert into FINAL_RESULT values(NULL, '%s', '%s', '%s', '%s')";
   private static final String SAVE_RESULT_OVERVIEW = "insert into STATS_OVERVIEW values(NULL, '%s', '%s', '%s', '%s')";
-  private static final String INGESTION_CREATE_STATEMENT = "create table %s (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, INGESTION_THROUGHPUT DOUBLE);";
-  private static final String INGESTION_INSERT_STATEMENT = "insert into %s values(NULL,'%i','%i','%i',%d)";
+  private static final String INGESTION_CREATE_STATEMENT = "create table %s (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE);";
+  private static final String INGESTION_INSERT_STATEMENT = "insert into %s values(NULL, %i, %i, %i, %i, %i, %i, %d, %i, %d)";
 
   private Connection mysqlConnection = null;
   private Config config = ConfigDescriptor.getInstance().getConfig();
@@ -229,8 +229,9 @@ public class MySqlRecorder implements ITestDataPersistence {
   }
 
   public String formatIngestionInsertStatement(String value){
-    // format looks like (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, INGESTION_THROUGHPUT DOUBLE)
-    return String.format(INGESTION_INSERT_STATEMENT, projectTableName, config.CLIENT_NUMBER, config.GROUP_NUMBER, config.DEVICE_NUMBER, Double.parseDouble(value));
+    // format looks like (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE)
+    return String.format(INGESTION_INSERT_STATEMENT, projectTableName, config.CLIENT_NUMBER, config.GROUP_NUMBER, config.DEVICE_NUMBER,
+            config.SENSOR_NUMBER, config.BATCH_SIZE, config.REAL_INSERT_RATE, config.POINT_STEP, Double.parseDouble(value));
   }
 
   // save the measurement results to three different tables: FINAL_RESULT, STATS_OVERVIEW and the project specific table

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -119,9 +119,9 @@ public class MySqlRecorder implements ITestDataPersistence {
         LOGGER.info("Table STATS_OVERVIEW create success!");
       }
       if (isProjectWanted() && !hasTable(projectTableName)) {
-        LOGGER.info("############################# We should create the metric specific table now. Project Type = " + config.PROJECT_TYPE);
-        if (config.PROJECT_TYPE.toLowerCase() == "ingestion") {
-            LOGGER.info("############################# Okay good");
+        LOGGER.info("####### We should create the metric specific table now. Project Type = '" + config.PROJECT_TYPE + "'");
+        if (config.PROJECT_TYPE.toLowerCase().contains("ingestion")) {
+            LOGGER.info("********************** Okay good");
             String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
             stat.executeUpdate(sql);
             LOGGER.info("Table {} create success!", projectTableName);
@@ -244,7 +244,7 @@ public class MySqlRecorder implements ITestDataPersistence {
     String sql_overview = String.format(SAVE_RESULT_OVERVIEW, projectID, operation, k, v);
 
     // only in case the project is wanted and currently there is an ingestion throughput measurement, we save the result
-    if (isProjectWanted() && operation.toLowerCase() == "ingestion" && k.toLowerCase() == "throughput") {
+    if (isProjectWanted() && operation.toLowerCase().contains("ingestion") && k.toLowerCase().contains("throughput")) {
       String sql_ingestion_measurement = formatIngestionInsertStatement(v);
       try {
         stat = mysqlConnection.createStatement();

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -122,7 +122,7 @@ public class MySqlRecorder implements ITestDataPersistence {
         if (config.PROJECT_TYPE.toLowerCase() == "ingestion") {
           String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
           stat.executeUpdate(sql);
-          LOGGER.info("Table " + projectTableName + " create success!");
+          LOGGER.info("Table {} create success!", projectTableName);
         } // else not supported yet. Only ingestion supported right now.
       }
       if (config.BENCHMARK_WORK_MODE.equals(Constants.MODE_TEST_WITH_DEFAULT_PATH) && !hasTable(
@@ -377,7 +377,7 @@ public class MySqlRecorder implements ITestDataPersistence {
             "'BATCH_SIZE'", "'" + config.BATCH_SIZE + "'");
         stat.addBatch(sql);
         sql = String.format(SAVE_CONFIG, "'" + projectID + "'",
-            "'POINT_STEP'", "'" + config.POINT_STEP + "'");
+            "'POINT_STEP'", "'" + Long.toString(config.POINT_STEP) + "'");
         stat.addBatch(sql);
         if (config.DB_SWITCH.equals(Constants.DB_IOT)) {
           sql = String.format(SAVE_CONFIG, "'" + projectID + "'",
@@ -387,7 +387,7 @@ public class MySqlRecorder implements ITestDataPersistence {
       }
       stat.executeBatch();
     } catch (SQLException e) {
-      LOGGER.error("{}将配置信息写入mysql失败，because ：{}", sql, e);
+      LOGGER.error("The sql statement '{}' raised the following error：{}", sql, e);
     } finally {
       if (stat != null) {
         try {

--- a/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
+++ b/iotdb-benchmark/src/main/java/cn/edu/tsinghua/iotdb/benchmark/measurement/persistence/mysql/MySqlRecorder.java
@@ -27,7 +27,7 @@ public class MySqlRecorder implements ITestDataPersistence {
   private static final String SAVE_RESULT_FINAL = "insert into FINAL_RESULT values(NULL, '%s', '%s', '%s', '%s')";
   private static final String SAVE_RESULT_OVERVIEW = "insert into STATS_OVERVIEW values(NULL, '%s', '%s', '%s', '%s')";
   private static final String INGESTION_CREATE_STATEMENT = "create table %s (id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT, CLIENT_NUMBER INT, GROUP_NUMBER INT, DEVICE_NUMBER INT, SENSOR_NUMBER INT, BATCH_SIZE INT, LOOP_RATE INT, REAL_INSERT_RATE DOUBLE, POINT_STEP INT, INGESTION_THROUGHPUT DOUBLE);";
-  private static final String INGESTION_INSERT_STATEMENT = "insert into %s values(NULL, %i, %i, %i, %i, %i, %i, %d, %i, %d)";
+  private static final String INGESTION_INSERT_STATEMENT = "insert into %s values(NULL, %d, %d, %d, %d, %d, %d, %f, %d, %f)";
 
   private Connection mysqlConnection = null;
   private Config config = ConfigDescriptor.getInstance().getConfig();
@@ -121,7 +121,6 @@ public class MySqlRecorder implements ITestDataPersistence {
       if (isProjectWanted() && !hasTable(projectTableName)) {
         if (config.PROJECT_TYPE.toLowerCase().contains("ingestion")) {
             String sql = String.format(INGESTION_CREATE_STATEMENT, projectTableName);
-            LOGGER.info("SQL that will be executed: " + sql);
             stat.executeUpdate(sql);
             LOGGER.info("Table {} create success!", projectTableName);
         } // else not supported yet. Only ingestion supported right now.


### PR DESCRIPTION
This PR adds a specific table to the measurements overview, that has the same name as the `PROJECT_ID` specified in the `conf/config.properties` file.

Currently only supports INGESTION mode and will save the respective necessary config fields that are needed in the INGESTION mode.

Metrics included are:
* CLIENT_NUMBER INT
* GROUP_NUMBER INT
* DEVICE_NUMBER INT
* SENSOR_NUMBER INT
* BATCH_SIZE INT
* LOOP INT
* REAL_INSERT_RATE DOUBLE
* POINT_STEP INT
* INGESTION_THROUGHPUT DOUBLE